### PR TITLE
feat: Enable cpu-only usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,28 @@ Download the model weights from the original repository as follows in the
 wget http://files.ipd.uw.edu/pub/sequence_diffusion/checkpoints/SEQDIFF_230205_dssp_hotspots_25mask_EQtasks_mod30.pt -P model
 wget http://files.ipd.uw.edu/pub/sequence_diffusion/checkpoints/SEQDIFF_221219_equalTASKS_nostrSELFCOND_mod30.pt -P model
 ```
+### Local installation on CPU-only env for testing purposes
+
+The original `environment.yml` file is not compatible with the CPU version of the model.
+For manual installation, please follow the steps below:
+
+```bash
+conda create -n protgen_cpu python=3.10
+conda activate protgen_cpu
+conda install pytorch==2.2.1 torchvision==0.17.1 torchaudio==2.2.1 cpuonly -c pytorch
+conda install -c dglteam/label/th21_cpu dgl
+pip install pydantic # DGL dependency
+pip install PyYAML # DGL dependency
+pip install biopython
+conda install opt_einsum -c conda-forge
+pip install icecream
+pip install e3nn
+pip install numpy==1.26.4 # To avoid problems with numpy >2.0
+pip install seaborn
+```
+Download the model weights from the original repository as follows in the
+`protein_generator` base directory:
+```bash
+wget http://files.ipd.uw.edu/pub/sequence_diffusion/checkpoints/SEQDIFF_230205_dssp_hotspots_25mask_EQtasks_mod30.pt -P model
+wget http://files.ipd.uw.edu/pub/sequence_diffusion/checkpoints/SEQDIFF_221219_equalTASKS_nostrSELFCOND_mod30.pt -P model
+```

--- a/model/se3_transformer/model/basis.py
+++ b/model/se3_transformer/model/basis.py
@@ -29,7 +29,19 @@ import e3nn.o3 as o3
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+
+if torch.cuda.is_available():
+    from torch.cuda.nvtx import range as nvtx_range
+else:
+    # Define a no-op for nvtx_range when CUDA is not available
+    from contextlib import contextmanager
+
+    @contextmanager
+    def nvtx_range(name):
+        try:
+            yield
+        finally:
+            pass
 
 from se3_transformer.runtime.utils import degree_to_dim
 

--- a/model/se3_transformer/model/layers/attention.py
+++ b/model/se3_transformer/model/layers/attention.py
@@ -34,7 +34,19 @@ from se3_transformer.model.fiber import Fiber
 from se3_transformer.model.layers.convolution import ConvSE3, ConvSE3FuseLevel
 from se3_transformer.model.layers.linear import LinearSE3
 from se3_transformer.runtime.utils import degree_to_dim, aggregate_residual, unfuse_features
-from torch.cuda.nvtx import range as nvtx_range
+
+if torch.cuda.is_available():
+    from torch.cuda.nvtx import range as nvtx_range
+else:
+    # Define a no-op for nvtx_range when CUDA is not available
+    from contextlib import contextmanager
+
+    @contextmanager
+    def nvtx_range(name):
+        try:
+            yield
+        finally:
+            pass
 
 
 class AttentionSE3(nn.Module):

--- a/model/se3_transformer/model/layers/convolution.py
+++ b/model/se3_transformer/model/layers/convolution.py
@@ -31,7 +31,19 @@ import torch
 import torch.nn as nn
 from dgl import DGLGraph
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+
+if torch.cuda.is_available():
+    from torch.cuda.nvtx import range as nvtx_range
+else:
+    # Define a no-op for nvtx_range when CUDA is not available
+    from contextlib import contextmanager
+
+    @contextmanager
+    def nvtx_range(name):
+        try:
+            yield
+        finally:
+            pass
 
 from se3_transformer.model.fiber import Fiber
 from se3_transformer.runtime.utils import degree_to_dim, unfuse_features

--- a/model/se3_transformer/model/layers/norm.py
+++ b/model/se3_transformer/model/layers/norm.py
@@ -27,7 +27,20 @@ from typing import Dict
 import torch
 import torch.nn as nn
 from torch import Tensor
-from torch.cuda.nvtx import range as nvtx_range
+
+if torch.cuda.is_available():
+    from torch.cuda.nvtx import range as nvtx_range
+else:
+    # Define a no-op for nvtx_range when CUDA is not available
+    from contextlib import contextmanager
+
+    @contextmanager
+    def nvtx_range(name):
+        try:
+            yield
+        finally:
+            pass
+
 
 from se3_transformer.model.fiber import Fiber
 


### PR DESCRIPTION
This pull request enables running the project in CPU-only environments while also ensuring compatibility in when CUDA is available.
The changes include adding detailed instructions for CPU-only installation in the documentation and implementing a fallback mechanism for `nvtx_range` when CUDA is not available.

### Documentation Updates:
* Added a new section in `README.md` with step-by-step instructions for setting up the project in a CPU-only environment, including specific package versions and dependencies required for compatibility.

### Code Compatibility Enhancements:
* Introduced a no-op fallback for `nvtx_range` in `basis.py`, `attention.py`, `convolution.py`, and `norm.py` to handle cases where CUDA is not available for `se3_transformer`. This ensures the code can run seamlessly on CPU-only setups.